### PR TITLE
bump material-ui version

### DIFF
--- a/example/material-ui/package.json
+++ b/example/material-ui/package.json
@@ -10,19 +10,19 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-core": "^6.4.5",
-    "babel-loader": "^6.2.1",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
-    "express": "^4.13.4",
-    "webpack": "^1.12.12"
+    "babel-core": "^6.18.2",
+    "babel-loader": "^6.2.8",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "express": "^4.14.0",
+    "webpack": "^1.13.3"
   },
   "dependencies": {
-    "material-ui": "^0.14.4",
-    "react": "^0.14.7",
+    "material-ui": "^0.16.4",
+    "react": "^15.4.1",
     "react-confirm": "^0.1.0",
-    "react-dom": "^0.14.7",
-    "react-tap-event-plugin": "^0.2.2"
+    "react-dom": "^15.4.1",
+    "react-tap-event-plugin": "^2.0.1"
   }
 }

--- a/example/material-ui/src/components/Confirmation.js
+++ b/example/material-ui/src/components/Confirmation.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import Dialog from 'material-ui/lib/dialog';
-import FlatButton from 'material-ui/lib/flat-button';
-import RaisedButton from 'material-ui/lib/raised-button';
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton';
 import { confirmable } from 'react-confirm';
+
+import Theme from '../theme'
 
 class Confirmation extends React.Component {
 
@@ -33,7 +35,7 @@ class Confirmation extends React.Component {
     ];
 
     return (
-      <div>
+      <Theme>
         <Dialog
           title={title}
           actions={actions}
@@ -43,7 +45,7 @@ class Confirmation extends React.Component {
         >
           {confirmation}
         </Dialog>
-      </div>
+      </Theme>
     );
   }
 }

--- a/example/material-ui/src/theme.js
+++ b/example/material-ui/src/theme.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import injectTapEventPlugin from 'react-tap-event-plugin';
+injectTapEventPlugin();
+
+const Theme = (props) => (
+  <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
+    { props.children }
+  </MuiThemeProvider>
+);
+
+export default Theme;


### PR DESCRIPTION
Update example code to use current Material-UI version with a theme wrapper component.

Also bumped the version of all the node modules in the example package.json file (tested: works).