### PR TITLE
Add support for ReactDOM 15/16

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ In the [example](https://github.com/haradakunihiko/react-confirm/tree/master/exa
 ### create confirmable component
 
 ```js
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { confirmable } from 'react-confirm';
 import Dialog from 'any-dialog-library'; // your choice.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "react-dom": "^0.14.7"
+    "react-dom": "^0.14.7 || 15.x || 16.x"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",


### PR DESCRIPTION
As discussed in #13, the peer dependency was out of date. This quick PR adds support for React 15 and 16.