### PR TITLE
Allow changing mounting node

### DIFF
--- a/src/createConfirmation.js
+++ b/src/createConfirmation.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-const createConfirmation = (Component, unmountDelay = 1000) => {
+const createConfirmation = (Component, unmountDelay = 1000, mountingNode = document.body) => {
   return (props) => {
-    const wrapper = document.body.appendChild(document.createElement('div'));
+    const wrapper = mountingNode.appendChild(document.createElement('div'));
 
     const promise = new Promise((resolve, reject) => {
       try {


### PR DESCRIPTION
Hi there,

Saw this issue https://github.com/haradakunihiko/react-confirm/issues/12 and stumbled upon the same problem recently. I'd like my confirm modal to be inside my DOM to benefit from parent class in my css.

This PR should not break anything and allow users to define their own custom mounting point if they want to.

Tell me what you think about that

Best