### PR TITLE
Add note on library versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ In the [example](https://github.com/haradakunihiko/react-confirm/tree/master/exa
 ## Demo
 https://codesandbox.io/s/react-confirm-with-react-bootstrap-kjju1
 
+## Versions
+
+- React 18+ users should use `react-confirm` version 0.2.x
+- React <=17 users should stick to `react-confirm` version 0.1.
+
 ## Usage
 1. create your dialog component.
 2. apply `confirmable` to your component (optional, but usually recommended).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://codesandbox.io/s/react-confirm-with-react-bootstrap-kjju1
 ## Versions
 
 - React 18+ users should use `react-confirm` version 0.2.x
-- React <=17 users should stick to `react-confirm` version 0.1.
+- React <=17 users should stick to `react-confirm` version 0.1.x
 
 ## Usage
 1. create your dialog component.


### PR DESCRIPTION
Thanks for merging my React 18 compatibility PR in! One thing I forgot to add to that PR is a change to the docs to make it clear to users which version of the library they should use.