### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export const confirm = createConfirmation(YourDialog);
 
 // This is optional. But wrapping function makes it easy to use.
 export function confirmWrapper(confirmation, options = {}) {
-  return confirm({ confirmation, options });
+  return confirm({ confirmation, ...options });
 }
 ```
 


### PR DESCRIPTION
Fixes options merging syntax, as `confirm` expects all the other options as root properties.