### PR TITLE
Add `options` to `ConfirmDialogProps` type

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -18,7 +18,7 @@ export type ConfirmDialogProps<P, R> = {
   /** Indicates if the dialog should be shown aka. someone is waiting for a promise. */
   show: boolean;
   /** Additional options passed to the dialog. */
-  options: Record<string, any>,
+  options: object,
 } & P;
 
 export type ConfirmDialog<P, R> = React.ComponentType<ConfirmDialogProps<P, R>> ;

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -17,6 +17,8 @@ export type ConfirmDialogProps<P, R> = {
   cancel: (value?: any) => void;
   /** Indicates if the dialog should be shown aka. someone is waiting for a promise. */
   show: boolean;
+  /** Additional options passed to the dialog. */
+  options: Record<string, any>,
 } & P;
 
 export type ConfirmDialog<P, R> = React.ComponentType<ConfirmDialogProps<P, R>> ;


### PR DESCRIPTION
Fixes: https://github.com/haradakunihiko/react-confirm/issues/87

I assume any type will work but given that the example shows `{}`, I thought it to be reasonable to assume that it is an object.