### PR TITLE
Unregister internally dismissed confirmations

### DIFF
--- a/__tests__/controls.test.ts
+++ b/__tests__/controls.test.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
 import { confirmable, createConfirmation, proceed, dismiss, cancel } from 'src';
 
 describe('External control behavior', () => {
@@ -36,6 +37,24 @@ describe('External control behavior', () => {
     const res = await Promise.race([
       p.then(() => 'resolved').catch(() => 'rejected'),
       new Promise((resolve) => setTimeout(() => resolve('pending'), 50)),
+    ]);
+    expect(res).toBe('pending');
+  });
+
+  it('removes internally dismissed dialogs from external controls', async () => {
+    const DismissibleDialog = ({ show, dismiss }: any) => (
+      show ? React.createElement('button', { 'data-testid': 'dismiss', onClick: dismiss }, 'Dismiss') : null
+    );
+    const confirm = createConfirmation(confirmable(DismissibleDialog));
+    const p = confirm({});
+
+    fireEvent.click(await screen.findByTestId('dismiss'));
+
+    expect(proceed(p, false)).toBe(false);
+
+    const res = await Promise.race([
+      p.then(() => 'resolved').catch(() => 'rejected'),
+      new Promise((resolve) => setTimeout(() => resolve('pending'), 10)),
     ]);
     expect(res).toBe('pending');
   });

--- a/dist/confirmable.js
+++ b/dist/confirmable.js
@@ -26,8 +26,12 @@ var jsx_runtime_1 = require("react/jsx-runtime");
 var react_1 = require("react");
 var confirmable = function (Component) {
     return function (_a) {
-        var dispose = _a.dispose, reject = _a.reject, resolve = _a.resolve, other = __rest(_a, ["dispose", "reject", "resolve"]);
+        var dispose = _a.dispose, reject = _a.reject, resolve = _a.resolve, registerSetShow = _a.registerSetShow, other = __rest(_a, ["dispose", "reject", "resolve", "registerSetShow"]);
         var _b = (0, react_1.useState)(true), show = _b[0], setShow = _b[1];
+        // Register setShow for external control
+        (0, react_1.useEffect)(function () {
+            registerSetShow === null || registerSetShow === void 0 ? void 0 : registerSetShow(setShow);
+        }, [registerSetShow]);
         var dismiss = function () {
             setShow(false);
             dispose();

--- a/dist/controls.d.ts
+++ b/dist/controls.d.ts
@@ -5,12 +5,14 @@ export type ConfirmationHandle<R> = {
     resolve: (value: R) => void;
     reject: (reason?: any) => void;
     dispose: () => void;
+    setShow?: (show: boolean) => void;
     settled?: boolean;
 };
 /**
  * Register a Promise and its handle to the registry
  */
 export declare function register<R>(promise: Promise<R>, handle: ConfirmationHandle<R>): void;
+export declare function unregister<R>(promise: Promise<R>): void;
 /**
  * Resolve a confirmation dialog and close it
  * @param promise The Promise to resolve

--- a/dist/controls.js
+++ b/dist/controls.js
@@ -3,6 +3,7 @@
 // Stores only control handles (resolve/reject/dispose), not UI state
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.register = register;
+exports.unregister = unregister;
 exports.proceed = proceed;
 exports.dismiss = dismiss;
 exports.cancel = cancel;
@@ -13,16 +14,20 @@ var active = new Map();
 function register(promise, handle) {
     active.set(promise, handle);
     // Auto cleanup after settlement
-    promise
-        .finally(function () {
+    var cleanup = function () {
         var h = active.get(promise);
         if (h)
             h.settled = true;
         active.delete(promise);
-    })
+    };
+    promise
+        .then(cleanup, cleanup)
         .catch(function () {
-        // Already handled by finally
+        // Already handled by cleanup
     });
+}
+function unregister(promise) {
+    active.delete(promise);
 }
 /**
  * Resolve a confirmation dialog and close it
@@ -31,17 +36,19 @@ function register(promise, handle) {
  * @returns true if successful
  */
 function proceed(promise, response) {
+    var _a;
     var handle = active.get(promise);
     if (!handle || handle.settled)
         return false;
     try {
+        (_a = handle.setShow) === null || _a === void 0 ? void 0 : _a.call(handle, false);
         handle.resolve(response);
     }
     finally {
         try {
             handle.dispose();
         }
-        catch (_a) {
+        catch (_b) {
             // Ignore
         }
         active.delete(promise);
@@ -55,13 +62,15 @@ function proceed(promise, response) {
  * @returns true if successful
  */
 function dismiss(promise) {
+    var _a;
     var handle = active.get(promise);
     if (!handle || handle.settled)
         return false;
     try {
+        (_a = handle.setShow) === null || _a === void 0 ? void 0 : _a.call(handle, false);
         handle.dispose();
     }
-    catch (_a) {
+    catch (_b) {
         // Ignore
     }
     active.delete(promise);
@@ -74,17 +83,19 @@ function dismiss(promise) {
  * @returns true if successful
  */
 function cancel(promise, reason) {
+    var _a;
     var handle = active.get(promise);
     if (!handle || handle.settled)
         return false;
     try {
+        (_a = handle.setShow) === null || _a === void 0 ? void 0 : _a.call(handle, false);
         handle.reject(reason);
     }
     finally {
         try {
             handle.dispose();
         }
-        catch (_a) {
+        catch (_b) {
             // Ignore
         }
         active.delete(promise);

--- a/dist/createConfirmation.js
+++ b/dist/createConfirmation.js
@@ -20,17 +20,25 @@ var createConfirmationCreater = function (mounter) {
         return function (props) {
             var mountId;
             var resolveRef = function () { };
+            var rejectRef = function () { };
+            var setShowRef;
+            var wrapped;
             function dispose() {
+                if (wrapped)
+                    (0, controls_1.unregister)(wrapped);
                 setTimeout(function () {
                     mounter.unmount(mountId);
                 }, unmountDelay);
             }
-            var rejectRef = function () { };
+            // Callback for confirmable to register its setShow function
+            var registerSetShow = function (setShow) {
+                setShowRef = setShow;
+            };
             var inner = new Promise(function (resolve, reject) {
                 resolveRef = resolve;
                 rejectRef = reject;
                 try {
-                    mountId = mounter.mount(Component, __assign({ reject: reject, resolve: resolve, dispose: dispose }, props), mountingNode);
+                    mountId = mounter.mount(Component, __assign({ reject: reject, resolve: resolve, dispose: dispose, registerSetShow: registerSetShow }, props), mountingNode);
                 }
                 catch (e) {
                     // keep behavior identical to JS version
@@ -38,7 +46,7 @@ var createConfirmationCreater = function (mounter) {
                     throw e;
                 }
             });
-            var wrapped = inner.then(function (result) {
+            wrapped = inner.then(function (result) {
                 dispose();
                 return result;
             }, function (err) {
@@ -46,7 +54,12 @@ var createConfirmationCreater = function (mounter) {
                 return Promise.reject(err);
             });
             // Register to controls layer for external control
-            (0, controls_1.register)(wrapped, { resolve: resolveRef, reject: rejectRef, dispose: dispose });
+            (0, controls_1.register)(wrapped, {
+                resolve: resolveRef,
+                reject: rejectRef,
+                dispose: dispose,
+                get setShow() { return setShowRef; }
+            });
             return wrapped;
         };
     };

--- a/dist/mounter/domTree.js
+++ b/dist/mounter/domTree.js
@@ -21,17 +21,20 @@ function createDomTreeMounter(defaultMountNode) {
         var key = Math.floor(Math.random() * (1 << 30)).toString(16);
         var parent = (mountNode || defaultMountNode || document.body);
         var wrapper = parent.appendChild(document.createElement('div'));
-        confirms[key] = wrapper;
         var root = (0, client_1.createRoot)(wrapper);
         root.render((0, jsx_runtime_1.jsx)(Component, __assign({}, props)));
+        confirms[key] = { wrapper: wrapper, root: root };
         callbacks.mounted && callbacks.mounted();
         return key;
     }
     function unmount(key) {
-        var wrapper = confirms[key];
+        var entry = confirms[key];
         delete confirms[key];
-        if (wrapper && wrapper.parentNode) {
-            wrapper.parentNode.removeChild(wrapper);
+        if (entry) {
+            entry.root.unmount();
+            if (entry.wrapper.parentNode) {
+                entry.wrapper.parentNode.removeChild(entry.wrapper);
+            }
         }
     }
     return {

--- a/dist/mounter/reactTree.d.ts
+++ b/dist/mounter/reactTree.d.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { TreeMounter } from '../types';
 export declare function createReactTreeMounter(mountNode?: Element | DocumentFragment | HTMLElement): TreeMounter;
-export declare function createMountPoint(reactTreeMounter: TreeMounter): () => import("react/jsx-runtime").JSX.Element;
+export declare function createMountPoint(reactTreeMounter: TreeMounter): () => React.JSX.Element;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -3,6 +3,8 @@ export type ConfirmableProps<P, R> = {
     dispose: () => void;
     resolve: (value: R | PromiseLike<R>) => void;
     reject: (reason?: any) => void;
+    /** Register a callback to control show state from outside */
+    registerSetShow?: (setShow: (show: boolean) => void) => void;
 } & P;
 export type ConfirmDialogProps<P, R> = {
     /** Dismiss dialog without resolving the promise. */

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -24,15 +24,21 @@ export function register<R>(
   active.set(promise, handle as ConfirmationHandle<unknown>);
 
   // Auto cleanup after settlement
+  const cleanup = () => {
+    const h = active.get(promise);
+    if (h) h.settled = true;
+    active.delete(promise);
+  };
+
   promise
-    .finally(() => {
-      const h = active.get(promise);
-      if (h) h.settled = true;
-      active.delete(promise);
-    })
+    .then(cleanup, cleanup)
     .catch(() => {
-      // Already handled by finally
+      // Already handled by cleanup
     });
+}
+
+export function unregister<R>(promise: Promise<R>): void {
+  active.delete(promise);
 }
 
 /**

--- a/src/createConfirmation.ts
+++ b/src/createConfirmation.ts
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { createDomTreeMounter } from './mounter/domTree';
 import type { ConfirmableDialog, Mounter } from './types';
-import { register } from './controls';
+import { register, unregister } from './controls';
 
 export const createConfirmationCreater = (mounter: Mounter) =>
   <P, R>(Component: ConfirmableDialog<P, R>, unmountDelay: number = 1000, mountingNode?: HTMLElement) => {
@@ -10,8 +10,10 @@ export const createConfirmationCreater = (mounter: Mounter) =>
       let resolveRef: (value: R) => void = () => {};
       let rejectRef: (reason?: any) => void = () => {};
       let setShowRef: ((show: boolean) => void) | undefined;
+      let wrapped: Promise<R> | undefined;
 
       function dispose() {
+        if (wrapped) unregister(wrapped);
         setTimeout(() => {
           mounter.unmount(mountId);
         }, unmountDelay);
@@ -34,7 +36,7 @@ export const createConfirmationCreater = (mounter: Mounter) =>
         }
       });
 
-      const wrapped = inner.then(
+      wrapped = inner.then(
         (result) => {
           dispose();
           return result;


### PR DESCRIPTION
## Summary
- unregister confirmations when a dialog is dismissed internally
- keep the dismissed confirmation promise pending while preventing later external `proceed`/`cancel` calls from settling it
- add regression coverage for internal dismiss followed by external controls

## Validation
- `jest --runTestsByPath __tests__/controls.test.ts --runInBand --silent`
- `tsc -p tsconfig.build.json`
- `jest --runInBand --silent`
- `tsc --noEmit`

Note: `tsc -p tsconfig.tests.json` currently fails because the test tsconfig references the missing `@types/node` package.